### PR TITLE
Added support for JAXB2 plugins.

### DIFF
--- a/xjc-maven-plugin-core/src/main/java/com/github/davidmoten/xjc/DriverMain.java
+++ b/xjc-maven-plugin-core/src/main/java/com/github/davidmoten/xjc/DriverMain.java
@@ -1,20 +1,14 @@
 package com.github.davidmoten.xjc;
 
 import com.sun.tools.xjc.Driver;
-import com.sun.tools.xjc.XJCFacade;
 
 public class DriverMain {
 
     private static final boolean USE_XJC_FACADE = true;
 
     public static void main(String[] args) throws Throwable {
-
-        if (USE_XJC_FACADE) {
-            XJCFacade.main(args);
-        } else if (Driver.run(args, System.out, System.out) != 0) {
+        if (Driver.run(args, System.out, System.out) != 0) {
             throw new Exception("xjc call failed, see logs above for details");
         }
-
     }
-
 }

--- a/xjc-maven-plugin-test/pom.xml
+++ b/xjc-maven-plugin-test/pom.xml
@@ -3,7 +3,7 @@
     <parent>
         <groupId>com.github.davidmoten</groupId>
         <artifactId>xjc-maven-plugin-parent</artifactId>
-        <version>0.1.3-SNAPSHOT</version>
+        <version>0.1.4-SNAPSHOT-1</version>
     </parent>
 
     <artifactId>xjc-maven-plugin-test</artifactId>
@@ -35,6 +35,11 @@
             <artifactId>jaxb-impl</artifactId>
             <version>${jaxb.version}</version>
             <scope>provided</scope>
+        </dependency>
+        <dependency>
+            <groupId>org.jvnet.jaxb2_commons</groupId>
+            <artifactId>jaxb2-basics</artifactId>
+            <version>1.11.1</version>
         </dependency>
         
         <!-- test -->
@@ -89,8 +94,28 @@
                     </execution>
                     <execution>
                         <id>gen-from-xsd-kml</id>
-                        <!-- generate sources from the java.util.logging 
-                            DTD -->
+                        <phase>generate-sources</phase>
+                        <goals>
+                            <goal>xjc</goal>
+                        </goals>
+                        <configuration>
+                            <systemProperties>
+                                <enableExternalEntityProcessing>true</enableExternalEntityProcessing>
+                            </systemProperties>
+                            <arguments>
+                                <!--These are the arguments you would normally
+                                    have put with a call to xjc-->
+                                <argument>-verbose</argument>
+                                <argument>-d</argument>
+                                <argument>${jaxb.generated}-dontinclude</argument>
+                                <argument>${project.basedir}/src/main/jaxb/kml-2-2/xsd</argument>
+                                <argument>-b</argument>
+                                <argument>${project.basedir}/src/main/jaxb/kml-2-2/bindings</argument>
+                            </arguments>
+                        </configuration>
+                    </execution>
+                    <execution>
+                        <id>gen-from-xsd-kml-episode-gen</id>
                         <phase>generate-sources</phase>
                         <goals>
                             <goal>xjc</goal>
@@ -105,13 +130,47 @@
                                 <argument>-verbose</argument>
                                 <argument>-d</argument>
                                 <argument>${jaxb.generated}-dontinclude</argument>
+                                <argument>-episode</argument>
+                                <argument>${project.build.directory}/kml.episode</argument>
                                 <argument>${project.basedir}/src/main/jaxb/kml-2-2/xsd</argument>
                                 <argument>-b</argument>
                                 <argument>${project.basedir}/src/main/jaxb/kml-2-2/bindings</argument>
                             </arguments>
                         </configuration>
                     </execution>
+                    <execution>
+                        <id>from-dtd-usePlugins</id>
+                        <phase>generate-sources</phase>
+                        <goals>
+                            <goal>xjc</goal>
+                        </goals>
+                        <configuration>
+                            <systemProperties>
+                                <enableExternalEntityProcessing>true</enableExternalEntityProcessing>
+                            </systemProperties>
+                            <arguments>
+                                <argument>-extension</argument>
+                                <argument>-verbose</argument>
+                                <argument>-Xequals</argument>
+                                <argument>-XhashCode</argument>
+                                <argument>-XtoString</argument>
+                                <argument>-d</argument>
+                                <argument>${jaxb.generated}</argument>
+                                <argument>-p</argument>
+                                <argument>plugin.support</argument>
+                                <argument>-dtd</argument>
+                                <argument>${project.basedir}/src/main/dtd/logger.dtd</argument>
+                            </arguments>
+                        </configuration>
+                    </execution>
                 </executions>
+                <dependencies>
+                    <dependency>
+                        <groupId>org.jvnet.jaxb2_commons</groupId>
+                        <artifactId>jaxb2-basics</artifactId>
+                        <version>1.11.1</version>
+                    </dependency>
+                </dependencies>
             </plugin>
             <plugin>
                 <groupId>org.codehaus.mojo</groupId>
@@ -139,6 +198,30 @@
                 <configuration>
                     <additionalJOption>-Xdoclint:none</additionalJOption>
                 </configuration>
+            </plugin>
+            <!-- Test purpose plugin - to allow .episode file appear in classpath-->
+            <plugin>
+                <groupId>org.apache.maven.plugins</groupId>
+                <artifactId>maven-resources-plugin</artifactId>
+                <version>3.1.0</version>
+                <executions>
+                  <execution>
+                    <id>default-resources</id>
+                    <goals>
+                      <goal>resources</goal>
+                    </goals>
+                    <configuration>
+                      <resources>
+                        <resource>
+                          <directory>${project.build.directory}</directory>
+                          <includes>
+                            <include>*.episode</include>
+                          </includes>
+                        </resource>
+                      </resources>
+                    </configuration>
+                  </execution>
+                </executions>
             </plugin>
         </plugins>
 

--- a/xjc-maven-plugin-test/pom.xml
+++ b/xjc-maven-plugin-test/pom.xml
@@ -3,7 +3,7 @@
     <parent>
         <groupId>com.github.davidmoten</groupId>
         <artifactId>xjc-maven-plugin-parent</artifactId>
-        <version>0.1.4-SNAPSHOT-1</version>
+        <version>0.1.4-SNAPSHOT</version>
     </parent>
 
     <artifactId>xjc-maven-plugin-test</artifactId>

--- a/xjc-maven-plugin-test/pom.xml
+++ b/xjc-maven-plugin-test/pom.xml
@@ -3,7 +3,7 @@
     <parent>
         <groupId>com.github.davidmoten</groupId>
         <artifactId>xjc-maven-plugin-parent</artifactId>
-        <version>0.1.4-SNAPSHOT</version>
+        <version>0.1.3-SNAPSHOT</version>
     </parent>
 
     <artifactId>xjc-maven-plugin-test</artifactId>

--- a/xjc-maven-plugin-test/src/test/java/com/github/davidmoten/xjc/XjcPluginTest.java
+++ b/xjc-maven-plugin-test/src/test/java/com/github/davidmoten/xjc/XjcPluginTest.java
@@ -1,10 +1,13 @@
 package com.github.davidmoten.xjc;
 
+import org.junit.Assert;
 import org.junit.Test;
 
 import dummy.ObjectFactory;
 import dummy.Param;
 import dummy.Record;
+
+import java.lang.reflect.Method;
 
 public class XjcPluginTest {
     
@@ -15,4 +18,28 @@ public class XjcPluginTest {
        System.out.println("Found generated class " + Record.class.getName());
     }
 
+    @Test
+    public void testJaxb2PluginGeneratedCodePresent() {
+        Assert.assertNotNull(getDeclaredMethod(plugin.support.Param.class, "toString"));
+        Assert.assertNotNull(getDeclaredMethod(plugin.support.Param.class, "equals"));
+        Assert.assertNotNull(getDeclaredMethod(plugin.support.Param.class, "hashCode"));
+        System.out.println("Jaxb2-basics plugins worked correctly");
+    }
+
+    @Test
+    public void testKmlEpisodeFileGenerated() {
+        Assert.assertNotNull(XjcPluginTest.class.getClassLoader().getResourceAsStream("kml.episode"));
+        System.out.println("episode file generated correctly");
+    }
+
+    private Method getDeclaredMethod(Class<?> clazz, String methodName)
+    {
+        for (Method method : clazz.getDeclaredMethods()) {
+          if(method.getName().equals(methodName)) {
+            return method;
+          }
+        }
+
+        throw new RuntimeException(new NoSuchMethodException(methodName));
+    }
 }

--- a/xjc-maven-plugin/pom.xml
+++ b/xjc-maven-plugin/pom.xml
@@ -13,9 +13,15 @@
 
     <properties>
         <maven.plugin.version>3.6.0</maven.plugin.version>
+        <plexus-build-api.version>0.0.7</plexus-build-api.version>
     </properties>
 
     <dependencies>
+        <dependency>
+            <groupId>org.sonatype.plexus</groupId>
+            <artifactId>plexus-build-api</artifactId>
+            <version>${plexus-build-api.version}</version>
+        </dependency>
         <dependency>
             <groupId>org.apache.maven</groupId>
             <artifactId>maven-plugin-api</artifactId>

--- a/xjc-maven-plugin/src/main/java/com/github/davidmoten/xjc/XjcMojo.java
+++ b/xjc-maven-plugin/src/main/java/com/github/davidmoten/xjc/XjcMojo.java
@@ -296,7 +296,7 @@ public final class XjcMojo extends AbstractMojo {
             }
         }
 
-        final File outputDir = new File(mavenProject.getBuild().getDirectory());
+        final File outputDir = new File(".");
         outputDir.mkdir();
         return outputDir;
     }

--- a/xjc-maven-plugin/src/main/java/com/github/davidmoten/xjc/XjcMojo.java
+++ b/xjc-maven-plugin/src/main/java/com/github/davidmoten/xjc/XjcMojo.java
@@ -296,9 +296,7 @@ public final class XjcMojo extends AbstractMojo {
             }
         }
 
-        final File outputDir = new File(".");
-        outputDir.mkdir();
-        return outputDir;
+        return new File(".");
     }
 
     private boolean isDirParamSpecifiedAndNotEmpty(List<String> arguments, int index) {


### PR DESCRIPTION
1) Added support for custom Jaxb2 plugins.
2) Made output dir generated sources seen by compiler plugin

Example:

```xml
<plugin>
        <groupId>com.github.davidmoten</groupId>
        <artifactId>xjc-maven-plugin</artifactId>
        <version>0.1.4-SNAPSHOT</version>
        <executions>
        ...
        </executions>
        <dependencies>
          <dependency>
            <groupId>org.jvnet.jaxb2_commons</groupId>
            <artifactId>jaxb2-basics</artifactId>
            <version>1.11.1</version>
          </dependency>
        </dependencies>
</plugin>
```

dependency jaxb2-basics and its dependencies will be added to classpath of jaxb-xjc execution.